### PR TITLE
spaces in path to war file supported

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/wildfly/WildflyBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/wildfly/WildflyBuilder.java
@@ -161,9 +161,9 @@ public class WildflyBuilder extends Builder {
 
     		listener.getLogger().println("Deploying "+warFilename+" ...");
     		if (server.length() > 0)
-    			result = cli.cmd("deploy "+warPath+" --server-groups="+server);
+    			result = cli.cmd("deploy \""+warPath+"\" --server-groups="+server);
     		else
-    			result = cli.cmd("deploy "+warPath);
+    			result = cli.cmd("deploy \""+warPath+"\"");
     		
     		response = getWildFlyResponse(result);   		
     		if (response.indexOf("{\"outcome\" => \"failed\"") >= 0) {


### PR DESCRIPTION
Hi,

Jenkins allows spaces in the names of the jobs, like "My Job".

Unfortunately that leads to a space character in a path to war file, so it must be quoted for "deploy" command.
